### PR TITLE
Added way to use NeoSWSerial together with PCINT handlers

### DIFF
--- a/NeoSWSerial.cpp
+++ b/NeoSWSerial.cpp
@@ -382,6 +382,7 @@ void NeoSWSerial::rxChar( uint8_t c )
 
 } // rxChar
 
+#ifndef NEOSWSERIAL_EXTERNAL_PCINT
 //----------------------------------------------------------------------------
 // Must define all of the vectors even though only one is used.
 
@@ -455,6 +456,10 @@ PCINT_ISR(1, PINE);
 
 #else
   #error MCU not supported by NeoSWSerial!
+#endif
+
+#else
+// It's assumed that client code will call NeoSWSerial::rxISR(PINB) in PCINT handler
 #endif
 
 //-----------------------------------------------------------------------------

--- a/NeoSWSerial.h
+++ b/NeoSWSerial.h
@@ -22,6 +22,12 @@
 // Both RX and TX read timer0 for determining elapsed time. Timer0 itself is
 // not reprogrammed; it is assumed to be running with a 4 microsecond step.
 //
+// By default NeoSWSerial defines handlers for all PCINT interrupts like
+// SoftwareSerial. If client code requires own pin change interrupt handlers,
+// it's possible to rebuild library with #define NEOSWSERIAL_EXTERNAL_PCINT.
+// In such case client code should call NeoSWSerial::rxISR(PINB) (assuming
+// that receivePin is on PORT B)
+//
 // Supported baud rates are 9600 (default), 19200 and 38400.
 // The baud rate is selectable at run time.
 //


### PR DESCRIPTION
Hi,

I've found that it's currently impossible to use NeoSWSerial together with own PCINT handlers, even if my handler is for completly different AVR port. 

I propose to merge followed change. It just disables built-in PCINT handlers and assumes that end-user will declare own PCINT handler for pin used for RX and call NeoSWSerial::rxISR() from it.