### PR TITLE
fix: prevent RX pin from receiving garbage data

### DIFF
--- a/src/NeoSWSerial.cpp
+++ b/src/NeoSWSerial.cpp
@@ -135,7 +135,7 @@ void NeoSWSerial::listen()
   if (listener)
     listener->ignore();
 
-  pinMode(rxPin, INPUT);
+  pinMode(rxPin, INPUT_PULLUP);
   rxBitMask = digitalPinToBitMask( rxPin );
   rxPort    = portInputRegister( digitalPinToPort( rxPin ) );
 


### PR DESCRIPTION
In some use cases of NeoSWSerial, the RX pin might be "disconnected/open drain" for some reason or another. In such a case, RX pin can switch on and off randomly therefore causing random pieces of data to be received. The solution I propose is simple: set mode of RX pin as `INPUT_PULLUP` instead of just `INPUT` so that whenever this pin becomes open drain, the state of this pin will be interpreted as idle (not receiving any data).