### PR TITLE
Added explicit TX port and mask selection on write operation.

### DIFF
--- a/src/NeoSWSerial.cpp
+++ b/src/NeoSWSerial.cpp
@@ -539,6 +539,9 @@ size_t NeoSWSerial::write(uint8_t txChar)
     //    the last 0 data bit.  Then we could wait for the
     //    remaining 1 data bits and stop bit with interrupts 
     //    re-enabled.
+    
+  txBitMask = digitalPinToBitMask( txPin );
+  txPort    = portOutputRegister( digitalPinToPort( txPin ) );
 
     while (txBit++ < 9) {   // repeat for start bit + 8 data bits
       if (b)      // if bit is set


### PR DESCRIPTION
The case as follows: two instances of NeoSWSerial are engaged. The first works in "listen-only" mode, while the second uses request-reply operation. After calling .listen() on first instance, the second instance does not transmit any data.
The problem is that txPort and txBitMask are static variables shared across instances, and in write() function they are not assigned and used from previous call to another port instance. So transmission happen to wrong port.
May be the cause of issue https://github.com/SlashDevin/NeoSWSerial/issues/33